### PR TITLE
Add the --noCache option to dump_wiki

### DIFF
--- a/bin/dump_wiki
+++ b/bin/dump_wiki
@@ -43,6 +43,10 @@ var argParser = require('yargs')
         alias: 'url',
         default: '{{host}}/{{domain}}/v1/page/html/{title}/{oldid}'
     })
+    .options('n', {
+        alias: 'noCache',
+        default: false
+    })
     //.default('apiURL', 'http://en.wikipedia.org/w/api.php')
     //.default('prefix', 'en.wikipedia.org')
     //.default('ns', '0')

--- a/lib/htmldump.js
+++ b/lib/htmldump.js
@@ -1,6 +1,4 @@
 "use strict";
-// Upgrade to es6
-require('core-js/shim');
 
 var P = require('bluebird');
 var Template = require('swagger-router').Template;
@@ -218,7 +216,8 @@ function makeDump (options) {
         uri: options.url,
         headers: {
             'user-agent': options.userAgent,
-            'accept-encoding': 'gzip'
+            'accept-encoding': 'gzip',
+            'cache-control': options.noCache ? 'no-cache' : undefined
         },
         retries: 5,
         timeout: 60000,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htmldump",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Parsoid HTML dump utility",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -14,16 +14,15 @@
     "url": "github.com/wikimedia/htmldumper"
   },
   "author": "Gabriel Wicke <gwicke@wikimedia.org>",
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/wikimedia/htmldumper/issues"
   },
   "dependencies": {
-    "bluebird": "~2.3.11",
-    "core-js": "^1.0.0",
-    "preq": "~0.3.1",
-    "sqlite3": "^3.0.5",
-    "swagger-router": "^0.5.6",
-    "yargs": "~1.2.1"
+    "bluebird": "^3.5.2",
+    "preq": "^0.5.6",
+    "sqlite3": "^4.0.2",
+    "swagger-router": "^0.7.1",
+    "yargs": "^12.0.2"
   }
 }


### PR DESCRIPTION
Allow requests to be issued with the `Cache-Control: no-cache` header.

Also update the dependencies and get rid of core-js.